### PR TITLE
fix: Delete unnecessary version prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v3.0.1
+
+### Fixed
+
+- Delete unnecessary version prefix
+
 ## v3.0.0
 
 ### Added

--- a/src/Tecan/TecanProtocol.php
+++ b/src/Tecan/TecanProtocol.php
@@ -88,7 +88,7 @@ final class TecanProtocol
     {
         $version = InstalledVersions::getPrettyVersion(self::PACKAGE_NAME);
         $commentCommands = new Collection([
-            new Comment('Created by ' . self::PACKAGE_NAME . " v.{$version}"),
+            new Comment('Created by ' . self::PACKAGE_NAME . " {$version}"),
             new Comment('Date: ' . Carbon::now()),
         ]);
 

--- a/tests/Unit/Tecan/TecanProtocolTest.php
+++ b/tests/Unit/Tecan/TecanProtocolTest.php
@@ -287,7 +287,7 @@ R;MM;;Eppis 32x1.5 ml Cooled;5;5;DestPCR;;96 Well PCR ABI semi-skirted;1;5;24;Tr
     {
         $version = InstalledVersions::getPrettyVersion(TecanProtocol::PACKAGE_NAME);
 
-        return "C;Created by mll-lab/liquid-handling-robotics v.{$version}
+        return "C;Created by mll-lab/liquid-handling-robotics {$version}
 C;Date: 2022-10-05 13:34:32
 ";
     }


### PR DESCRIPTION
- [x] Added automated tests
- [x] Documented for all relevant versions
- [x] Updated the changelog

**Changes**

- Delete unnecessary version prefix in gwl header (`v.v3.0.0` -> `v3.0.0`)
